### PR TITLE
Add vote stack

### DIFF
--- a/bin/dk-functions-cdk.ts
+++ b/bin/dk-functions-cdk.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-//import { Tags } from '@aws-cdk/core'
 import { App, Tags } from 'aws-cdk-lib';
 import { ViewerCountStack } from './../lib/viewer-count-stack';
+import { VoteCFPStack } from './../lib/vote-cfp-stack';
 import { APIGatewayStack } from './../lib/apigateway-stack';
 import { BuildConfig } from './../lib/build-config';
 import { CertManagerStack } from './../lib/cert-manager-stack';
@@ -59,6 +59,13 @@ async function Main()
         }
     }, buildConfig);
 
+    const voteCFPStack = new VoteCFPStack(app, `voteCFPStack-${buildConfig.Environment}`, {
+        stackName: `voteCFP-${buildConfig.Environment}`,
+        env: {
+            region: buildConfig.AWSProfileRegion,
+        }
+    }, buildConfig);
+
     const certManager = new CertManagerStack(app, `certManagerStack-${buildConfig.Environment}`,{
         stackName: `certManager-${buildConfig.Environment}`,
         env: {
@@ -69,11 +76,16 @@ async function Main()
     const apiGatewayStack = new APIGatewayStack(app, `apigGatewayStack-${buildConfig.Environment}`, {
         certificate: certManager.certificate,
         hostedZone: certManager.hostedZone,
+        lambda: {
+            voteCFP: voteCFPStack.voteCFPFunction
+        },
         stackName: `apiGatewayStack-${buildConfig.Environment}`,
         env: {
             region: buildConfig.AWSProfileRegion,
         }
     }, buildConfig);
-    apiGatewayStack.addDependency(viewerCountStack);
+    //apiGatewayStack.addDependency(viewerCountStack);
+    //apiGatewayStack.addDependency(voteCFPStack);
+
 }
 Main();

--- a/lib/vote-cfp-stack.ts
+++ b/lib/vote-cfp-stack.ts
@@ -1,0 +1,43 @@
+import { Construct } from 'constructs';
+import { Stack, StackProps, RemovalPolicy } from 'aws-cdk-lib';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { BuildConfig } from './build-config'
+import { IFunction } from 'aws-cdk-lib/aws-lambda';
+
+
+export class VoteCFPStack extends Stack {
+    public readonly voteCFPFunction: IFunction 
+
+    constructor(scope: Construct, id: string, props: StackProps, buildConfig: BuildConfig) {
+        super(scope, id, props)
+
+        // Dynamo DB
+
+        const voteTable = new Table(this, 'VoteTable', {
+            billingMode: BillingMode.PAY_PER_REQUEST,
+            partitionKey: { name: 'globalIp', type: AttributeType.STRING },
+            sortKey: { name: 'talkId', type: AttributeType.NUMBER }, 
+            removalPolicy: RemovalPolicy.RETAIN,
+        });
+
+        // Lambda: Vote
+
+        this.voteCFPFunction = new NodejsFunction(this, 'voteCFP',{
+            entry: 'src/vote_cfp.ts',
+            environment: {
+                TABLENAME: voteTable.tableName,
+            },
+        });
+        this.voteCFPFunction.addToRolePolicy(new PolicyStatement({
+            resources: [
+                voteTable.tableArn,
+            ],
+            actions: [
+                'dynamodb:PutItem',
+            ]
+        }));
+    }
+}
+

--- a/lib/vote-cfp-stack.ts
+++ b/lib/vote-cfp-stack.ts
@@ -17,8 +17,8 @@ export class VoteCFPStack extends Stack {
 
         const voteTable = new Table(this, 'VoteTable', {
             billingMode: BillingMode.PAY_PER_REQUEST,
-            partitionKey: { name: 'globalIp', type: AttributeType.STRING },
-            sortKey: { name: 'talkId', type: AttributeType.NUMBER }, 
+            partitionKey: { name: 'eventName', type: AttributeType.STRING },
+            sortKey: { name: 'timestamp', type: AttributeType.NUMBER },
             removalPolicy: RemovalPolicy.RETAIN,
         });
 

--- a/src/vote_cfp.ts
+++ b/src/vote_cfp.ts
@@ -18,13 +18,16 @@ export const handler = async (event: any = {}): Promise<any> => {
             throw new Error('Error400: cannot get talkId');
     }
     
+    // Timezone is in UTC.
+    const timestamp = Date.now();
     try {
         const command = new PutItemCommand({
             TableName: TABLENAME,
             Item: {
+                eventName: { S: String(eventName)},
+                timestamp: { N: String(timestamp)},
                 globalIp: { S: String(globalIp)},
                 talkId: { N: String(talkId) },
-                eventName: { S: String(eventName)},
             },
         });
         await dynamodb.send(command);

--- a/src/vote_cfp.ts
+++ b/src/vote_cfp.ts
@@ -1,0 +1,36 @@
+import { DynamoDB, PutItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
+
+const dynamodb = new DynamoDB({});
+const TABLENAME = process.env.TABLENAME || "";
+
+export const handler = async (event: any = {}): Promise<any> => {
+    
+    const globalIp = String(event.globalIp);
+    if (!globalIp) {
+            throw new Error('Error400: cannot get global ip');
+    }
+    const eventName =  String(event.eventName);
+    if (!eventName) {
+            throw new Error('Error400: cannot get event name');
+    }
+    const talkId =  Number(event.talkId);
+    if (!talkId) {
+            throw new Error('Error400: cannot get talkId');
+    }
+    
+    try {
+        const command = new PutItemCommand({
+            TableName: TABLENAME,
+            Item: {
+                globalIp: { S: String(globalIp)},
+                talkId: { N: String(talkId) },
+                eventName: { S: String(eventName)},
+            },
+        });
+        await dynamodb.send(command);
+    } catch(error) {
+        console.log(error);
+    }
+
+    return { 'message' : 'ok' }
+};


### PR DESCRIPTION
## Summary

- 投票用のAPI(Stack)を作成した
- close: https://github.com/cloudnativedaysjp/dreamkast-functions/issues/4

## 修正内容

- 投票用のAPIを作成した
  - 同一IP＆同一talkIdには1票しか入らないようにdynamoDBを設計
- apigatewayのaddDependencyをコメントアウトした
  - ここら辺要件はなく、あったら便利かなレベルで作っていた
  - dependencyつけた場合、apigatewayを削除しないと他のstackの削除ができなくなり不便だった
- `Access-Control-Allow-Methods`にはPOSTとGET両方を許可する設定をいれた
  - 使用するAPIごとに作った方が綺麗だけど、細かくなりすぎるかなと思いやめました
  - した方がよい等あればコメントいただければ修正します 