### PR TITLE
devのAccessControlAllowOriginをワイルドにしました

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -40,7 +40,7 @@
       "DomainName" : "api.dev.cloudnativedays.jp",
       "HostedZoneID" : "Z0898116244TOPT4X7AGI",
       "ZoneName" : "cloudnativedays.jp",
-      "AccessControlAllowOrigin": "https://staging.dev.cloudnativedays.jp",
+      "AccessControlAllowOrigin": "*",
       "GetTracksURL": "https://staging.dev.cloudnativedays.jp/api/v1/tracks",
       "Environment": "dev"
     },


### PR DESCRIPTION
devの用途として、ReviewAppや各自のローカル環境に立ち上げたDKから通信をしたい場合がある。その場合、`https://staging.dev.cloudnativedays.jp`だとエラーとなり検証できないため修正