### PR TITLE
fix/add_policy_for_DnsValidatedCertificate

### DIFF
--- a/test/__snapshots__/cert-manager-stack.test.ts.snap
+++ b/test/__snapshots__/cert-manager-stack.test.ts.snap
@@ -86,6 +86,21 @@ exports[`snapshot test 1`] = `
             },
             {
               "Action": "route53:changeResourceRecordSets",
+              "Condition": {
+                "ForAllValues:StringEquals": {
+                  "route53:ChangeResourceRecordSetsActions": [
+                    "UPSERT",
+                  ],
+                  "route53:ChangeResourceRecordSetsRecordTypes": [
+                    "CNAME",
+                  ],
+                },
+                "ForAllValues:StringLike": {
+                  "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+                    "*.api.test.cloudnativedays.jp",
+                  ],
+                },
+              },
               "Effect": "Allow",
               "Resource": {
                 "Fn::Join": [


### PR DESCRIPTION
- renoveteによるアップデートでsnapshotと差分が発生しCIがこけている
  -  https://github.com/cloudnativedaysjp/dreamkast-functions/actions/runs/3333788268/jobs/5516077344#step:6:24
- パッケージのアップデートでConditionが追加されたみたいなのでsnapshotを再生成した
  - FYI: https://github.com/aws/aws-cdk/commit/9457e82044e4efd29cf193f9b1b87ff1e39823db
 