### PR TITLE
Feat/add option method to viewer count resource

### DIFF
--- a/lib/apigateway-stack.ts
+++ b/lib/apigateway-stack.ts
@@ -92,7 +92,12 @@ export class APIGatewayStack extends Stack {
         // TRACKS
         const tracks = event.addResource('tracks');
         const trackid = tracks.addResource('{trackId}');
-        const viewerCount = trackid.addResource('viewer_count');
+        const viewerCount = trackid.addResource('viewer_count', {
+            defaultCorsPreflightOptions: {
+                statusCode: 200,
+                allowOrigins: [`'${buildConfig.AccessControlAllowOrigin}'`],
+              }
+        });
 
         // TALKS
         const talks = event.addResource('talks');


### PR DESCRIPTION
- viewer_count リソースにpreflight用のOPTIONSメソッドを追加しました

  - 現状だとdreamkast-uiからviewer_countをGETしてもpreflightでCORS ERRORとなる
  - awsのドキュメント的にはCORSを有効化する際には OPTIONS メソッドを実装する必要があると書いてある
    - ref: https://docs.aws.amazon.com/ja_jp/apigateway/latest/developerguide/how-to-cors.html 
  - 以前対応したissue https://github.com/cloudnativedaysjp/dreamkast-functions/pull/7 の時はpreflightが発生しなかったので設定はいれていなかった