### PR TITLE
Refactor/apigateway

### DIFF
--- a/lib/apigateway-stack.ts
+++ b/lib/apigateway-stack.ts
@@ -255,7 +255,7 @@ export class APIGatewayStack extends Stack {
             },
         );
 
-        // POST /{event}/talk/{trackID}/viewer_count -> GetViewerCountFunction
+        // POST /talk/{trackID}/vote -> VoteCFP
         vote.addMethod('POST',
             // Integration
             new apigateway.LambdaIntegration( props.lambda.voteCFP,
@@ -265,7 +265,7 @@ export class APIGatewayStack extends Stack {
                     passthroughBehavior: apigateway.PassthroughBehavior.NEVER,
                     requestTemplates: {
                         'application/json': `{
-                            "eventName":"$util.escapeJavaScript($input.params().get("path").get("eventName"))",
+                            "eventAbbr":"$util.escapeJavaScript($input.path('$').eventAbbr)",
                             "talkId": "$util.escapeJavaScript($input.params().get("path").get("talkId"))",
                             "globalIp": "$util.escapeJavaScript($context.identity.sourceIp)"
                         }`,
@@ -281,7 +281,6 @@ export class APIGatewayStack extends Stack {
             {
                 requestValidator: requestValidator,
                 requestParameters: {
-                    "method.request.path.eventName": true,
                     "method.request.path.talkId": true,
                 },
                 methodResponses: [

--- a/lib/apigateway-stack.ts
+++ b/lib/apigateway-stack.ts
@@ -9,7 +9,7 @@ import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 
-import { ViewerCountSchema, ProfilePointSchema, ProfilePointsSchema } from './schemas';
+import { ViewerCountSchema, ProfilePointSchema, ProfilePointsSchema, VoteSchema } from './schemas';
 import { BuildConfig } from './build-config'
 
 export interface APIGatewayProps extends StackProps {
@@ -121,6 +121,13 @@ export class APIGatewayStack extends Stack {
             modelName: 'DkfViewerCount',
             schema: ViewerCountSchema,
         })
+
+        const voteModel = api.addModel('voteModel',{
+            contentType: 'application/json',
+            modelName: 'Vote',
+            schema: VoteSchema,
+        })
+
         const profilePointModel = api.addModel('profilePointModel',{
             contentType: 'application/json',
             modelName: 'ProfilePoint',
@@ -282,6 +289,9 @@ export class APIGatewayStack extends Stack {
                 requestValidator: requestValidator,
                 requestParameters: {
                     "method.request.path.talkId": true,
+                },
+                requestModels: {
+                    'application/json': voteModel,
                 },
                 methodResponses: [
                     methodResponses200,

--- a/lib/apigateway-stack.ts
+++ b/lib/apigateway-stack.ts
@@ -118,7 +118,7 @@ export class APIGatewayStack extends Stack {
 
         const viewerCountModel = api.addModel('viewerCountModel',{
             contentType: 'application/json',
-            modelName: 'DkfViewerCount',
+            modelName: 'ViewerCount',
             schema: ViewerCountSchema,
         })
 

--- a/lib/apigateway-stack.ts
+++ b/lib/apigateway-stack.ts
@@ -92,7 +92,6 @@ export class APIGatewayStack extends Stack {
         
         const root = api.root;
         const apiv1 = root.addResource('api').addResource('v1')
-        const event = apiv1.addResource('{eventAbbr}');
 
         // TRACKS
         const tracks = apiv1.addResource('tracks');
@@ -110,7 +109,7 @@ export class APIGatewayStack extends Stack {
         const vote = talkId.addResource('vote');
 
         // Profile
-        const profiles = event.addResource('profile');
+        const profiles = apiv1.addResource('profile');
         const profileId = profiles.addResource('{profileId}');
         const point = profileId.addResource('point');
         const points = profileId.addResource('points');
@@ -303,8 +302,8 @@ export class APIGatewayStack extends Stack {
                     passthroughBehavior: apigateway.PassthroughBehavior.NEVER,
                     requestTemplates: {
                         'application/json': `{
+                            "conference":"$util.escapeJavaScript($input.path('$').eventAbbr)",
                             "profileId":"$util.escapeJavaScript($input.params().get("path").get("profileId"))",
-                            "conference":"$util.escapeJavaScript($input.params().get("path").get("eventName"))",
                             "point": "$util.escapeJavaScript($input.path('$').point)",
                             "reasonId":"$util.escapeJavaScript($input.path('$').reasonId)"
                         }`,
@@ -320,7 +319,6 @@ export class APIGatewayStack extends Stack {
             {
                 requestValidator: requestValidator,
                 requestParameters: {
-                    "method.request.path.eventName": true,
                     "method.request.path.profileId": true,
                 },
                 requestModels: {
@@ -346,7 +344,7 @@ export class APIGatewayStack extends Stack {
                 requestTemplates: {
                     'application/json': `{
                         "profileId":"$util.escapeJavaScript($input.params().get("path").get("profileId"))",
-                        "conference":"$util.escapeJavaScript($input.params().get("path").get("eventName"))"
+                        "conference":"$util.escapeJavaScript($input.params("eventAbbr"))"
                     }`,
                 },
                 integrationResponses: [
@@ -360,7 +358,7 @@ export class APIGatewayStack extends Stack {
         {
             requestValidator: requestValidator,
             requestParameters: {
-                "method.request.path.eventName": true,
+                "method.request.querystring.eventAbbr": false,
                 "method.request.path.profileId": true,
             },
             methodResponses: [

--- a/lib/apigateway-stack.ts
+++ b/lib/apigateway-stack.ts
@@ -92,7 +92,12 @@ export class APIGatewayStack extends Stack {
         // TRACKS
         const tracks = event.addResource('tracks');
         const trackid = tracks.addResource('{trackId}');
-        const viewerCount = trackid.addResource('viewer_count');
+        const viewerCount = trackid.addResource('viewer_count', {
+            defaultCorsPreflightOptions: {
+                statusCode: 200,
+                allowOrigins: [`'${buildConfig.AccessControlAllowOrigin}'`],
+              }
+        });
 
         // TALKS
         const talks = event.addResource('talks');

--- a/lib/apigateway-stack.ts
+++ b/lib/apigateway-stack.ts
@@ -60,6 +60,10 @@ export class APIGatewayStack extends Stack {
         domainName.addBasePathMapping(api,{
             basePath: '',
         });
+        // Not used to follow the dk swagger specifications
+        //domainName.addApiMapping(api.deploymentStage,{
+        //    basePath: 'api/v1',
+        //});
 
          // A Record
         new ARecord(this, 'APIARecod', {
@@ -87,20 +91,21 @@ export class APIGatewayStack extends Stack {
         /* === [ RESOURCES ] === */
         
         const root = api.root;
-        const event = root.addResource('{eventName}');
+        const apiv1 = root.addResource('api').addResource('v1')
+        const event = apiv1.addResource('{eventAbbr}');
 
         // TRACKS
-        const tracks = event.addResource('tracks');
+        const tracks = apiv1.addResource('tracks');
         const trackid = tracks.addResource('{trackId}');
         const viewerCount = trackid.addResource('viewer_count', {
             defaultCorsPreflightOptions: {
                 statusCode: 200,
                 allowOrigins: [`'${buildConfig.AccessControlAllowOrigin}'`],
-              }
+            }
         });
 
         // TALKS
-        const talks = event.addResource('talks');
+        const talks = apiv1.addResource('talks');
         const talkId = talks.addResource('{talkId}')
         const vote = talkId.addResource('vote');
 

--- a/lib/profile-point-stack.ts
+++ b/lib/profile-point-stack.ts
@@ -19,8 +19,8 @@ export class ProfilePointStack extends Stack {
 
         const profilePointTable = new Table(this, 'Table', {
             billingMode: BillingMode.PAY_PER_REQUEST,
-            partitionKey: { name: 'profileId#conference', type: AttributeType.STRING },
-            sortKey: { name: 'timestamp', type: AttributeType.NUMBER },
+            partitionKey: { name: 'profileId', type: AttributeType.NUMBER },
+            sortKey: { name: 'conference#timestamp', type: AttributeType.STRING },
             removalPolicy: RemovalPolicy.RETAIN,
         });
 

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -21,10 +21,13 @@ export const ProfilePointSchema: JsonSchema = {
     title: 'profilePointResponse',
     type: JsonSchemaType.OBJECT,
     additionalProperties: false,
-    required: [ "point" ],
+    required: [ "point", "eventAbbr" ],
     properties: {
         point: {
             type: JsonSchemaType.NUMBER,
+        },
+        eventAbbr:{
+            type: JsonSchemaType.STRING,
         },
         reasonId: {
             type: JsonSchemaType.NUMBER,

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -16,6 +16,19 @@ export const ViewerCountSchema: JsonSchema = {
     },
 }
 
+export const VoteSchema: JsonSchema = {
+    schema: JsonSchemaVersion.DRAFT4,
+    title: 'voteResponse',
+    type: JsonSchemaType.OBJECT,
+    additionalProperties: false,
+    required: [ "eventAbbr" ],
+    properties: {
+        eventAbbr: {
+            type: JsonSchemaType.STRING,
+        },
+    },
+}
+
 export const ProfilePointSchema: JsonSchema = {
     schema: JsonSchemaVersion.DRAFT4,
     title: 'profilePointResponse',

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -5,12 +5,12 @@ export const ViewerCountSchema: JsonSchema = {
     title: 'viewerCountResponse',
     type: JsonSchemaType.OBJECT,
     additionalProperties: false,
-    required: [ "track_id", "viewer_count"],
+    required: [ "trackId", "viewerCount"],
     properties: {
-        track_id: {
+        trackId: {
             type: JsonSchemaType.NUMBER,
         },
-        viewer_count: {
+        viewerCount: {
             type: JsonSchemaType.NUMBER,
         },
     },

--- a/lib/vote-cfp-stack.ts
+++ b/lib/vote-cfp-stack.ts
@@ -17,7 +17,7 @@ export class VoteCFPStack extends Stack {
 
         const voteTable = new Table(this, 'VoteTable', {
             billingMode: BillingMode.PAY_PER_REQUEST,
-            partitionKey: { name: 'eventName', type: AttributeType.STRING },
+            partitionKey: { name: 'eventAbbr', type: AttributeType.STRING },
             sortKey: { name: 'timestamp', type: AttributeType.NUMBER },
             removalPolicy: RemovalPolicy.RETAIN,
         });

--- a/src/get_profile_point.ts
+++ b/src/get_profile_point.ts
@@ -1,5 +1,5 @@
 import { DynamoDB, QueryCommand } from '@aws-sdk/client-dynamodb';
-import { unmarshall } from '@aws-sdk/util-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 
 const dynamodb = new DynamoDB({})
 const TABLENAME = process.env.TABLENAME || "";
@@ -8,6 +8,7 @@ class profilePoint{
     point: number;
     reasonId: number;
     timestamp: number;
+    eventAbbr: string;
 }
 
 export const handler = async (event: any = {}): Promise<any> => {
@@ -16,34 +17,50 @@ export const handler = async (event: any = {}): Promise<any> => {
     if (isNaN(profileId)) {
         throw new Error('Error400: NaN');
     }
-    const conference = String(event.conference) ;
-    if (!conference) {
-        throw new Error('Error400: cannot get conference');
-    }
 
     if (!TABLENAME) {
         throw new Error('Error500: TABLENAME is not defined')
     }
 
-    const records = await dynamodb.send(new QueryCommand({
-        TableName: TABLENAME,
-        ExpressionAttributeNames: {
-            "#pk": "profileId#conference",
-        },
-        ExpressionAttributeValues: {
-            ":pc": {
-                S: `${profileId}#${conference}`,
-            },
-        },
-        KeyConditionExpression: "#pk = :pc",
-    }));
+    const conference = String(event.conference) ;
+    const cmd = (() => {
+        if (conference) {
+            return new QueryCommand({
+                TableName: TABLENAME,
+                ExpressionAttributeNames: {
+                    "#pk": "profileId",
+                    "#sk": "conference#timestamp",
+                },
+                ExpressionAttributeValues: marshall({
+                    ":pc": profileId,
+                    ":sk": `${conference}#`,
+                }),
+                KeyConditionExpression: "#pk = :pc AND begins_with(#sk, :sk)",
+            });
+        } else {
+            return new QueryCommand({
+                TableName: TABLENAME,
+                ExpressionAttributeNames: {
+                    "#pk": "profileId",
+                },
+                ExpressionAttributeValues: marshall({
+                    ":pc": profileId,
+                }),
+                KeyConditionExpression: "#pk = :pc",
+            });
+        }
+    })();
+
+    const records = await dynamodb.send(cmd);
 
     const points = records.Items?.map((item) => {
         const record = unmarshall(item);
+
         const pp: profilePoint = {
-            point: record.point,
-            reasonId: record.reasonId,
-            timestamp: record.timestamp,
+            point: record['point'],
+            reasonId: record['reasonId'],
+            timestamp: record['profileId'],
+            eventAbbr: record['conference#timestamp'].split('#')[0],
         };
         return pp;
     }) || [];

--- a/src/get_viewer_count.ts
+++ b/src/get_viewer_count.ts
@@ -26,8 +26,8 @@ export const handler = async (event: any = {}): Promise<any> => {
 
     const item = unmarshall(record.Item)
     return {
-        track_id: trackId,
-        viewer_count: item.viewerCount,
+        trackId: trackId,
+        viewerCount: item.viewerCount,
     }
 };
 

--- a/src/post_profile_point.ts
+++ b/src/post_profile_point.ts
@@ -36,8 +36,8 @@ export const handler = async (event: any = {}): Promise<any> => {
         const command = new PutItemCommand({
             TableName: TABLENAME,
             Item: {
-                'profileId#conference': { S: `${profileId}#${conference}` },
-                'timestamp': { N: String(timestamp)},
+                'profileId': { N: String(profileId)},
+                'conference#timestamp': { S: `${conference}#${timestamp}`},
                 'point': { N: String(point)},
                 'reasonId': { N: String(reasonId)},
             },

--- a/src/vote_cfp.ts
+++ b/src/vote_cfp.ts
@@ -1,4 +1,4 @@
-import { DynamoDB, PutItemCommand, UpdateItemCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDB, PutItemCommand } from '@aws-sdk/client-dynamodb';
 
 const dynamodb = new DynamoDB({});
 const TABLENAME = process.env.TABLENAME || "";
@@ -9,9 +9,9 @@ export const handler = async (event: any = {}): Promise<any> => {
     if (!globalIp) {
             throw new Error('Error400: cannot get global ip');
     }
-    const eventName =  String(event.eventName);
-    if (!eventName) {
-            throw new Error('Error400: cannot get event name');
+    const eventAbbr =  String(event.eventAbbr);
+    if (!eventAbbr) {
+            throw new Error('Error400: cannot get eventAbbr');
     }
     const talkId =  parseInt(event.talkId);
     if (isNaN(talkId)) {
@@ -24,7 +24,7 @@ export const handler = async (event: any = {}): Promise<any> => {
         const command = new PutItemCommand({
             TableName: TABLENAME,
             Item: {
-                eventName: { S: String(eventName)},
+                eventAbbr: { S: String(eventAbbr)},
                 timestamp: { N: String(timestamp)},
                 globalIp: { S: String(globalIp)},
                 talkId: { N: String(talkId) },

--- a/test/__snapshots__/profile-point-stack.test.ts.snap
+++ b/test/__snapshots__/profile-point-stack.test.ts.snap
@@ -15,22 +15,22 @@ exports[`snapshot test 1`] = `
       "Properties": {
         "AttributeDefinitions": [
           {
-            "AttributeName": "profileId#conference",
-            "AttributeType": "S",
+            "AttributeName": "profileId",
+            "AttributeType": "N",
           },
           {
-            "AttributeName": "timestamp",
-            "AttributeType": "N",
+            "AttributeName": "conference#timestamp",
+            "AttributeType": "S",
           },
         ],
         "BillingMode": "PAY_PER_REQUEST",
         "KeySchema": [
           {
-            "AttributeName": "profileId#conference",
+            "AttributeName": "profileId",
             "KeyType": "HASH",
           },
           {
-            "AttributeName": "timestamp",
+            "AttributeName": "conference#timestamp",
             "KeyType": "RANGE",
           },
         ],

--- a/test/__snapshots__/vote-cfp-stack.test.ts.snap
+++ b/test/__snapshots__/vote-cfp-stack.test.ts.snap
@@ -15,7 +15,7 @@ exports[`snapshot test 1`] = `
       "Properties": {
         "AttributeDefinitions": [
           {
-            "AttributeName": "eventName",
+            "AttributeName": "eventAbbr",
             "AttributeType": "S",
           },
           {
@@ -26,7 +26,7 @@ exports[`snapshot test 1`] = `
         "BillingMode": "PAY_PER_REQUEST",
         "KeySchema": [
           {
-            "AttributeName": "eventName",
+            "AttributeName": "eventAbbr",
             "KeyType": "HASH",
           },
           {


### PR DESCRIPTION
- https://github.com/cloudnativedaysjp/dreamkast/pull/1618 でコメント頂いた件、下記対応しました
  - URLの`eventName`を`api/v1`に変更
    - 変更により、eventNameをpathから取れなくなったのでprofilePointの仕様を若干変更しました
      - pathで受け取っていたeventName情報をbodyまたはクエリで受け取るように変更しました
    - 補足としてコード上でコメントいれてます
  - `eventName`という表現を`eventAbbr`に変更

- 下記のコマンドで動作確認可能です
  - oO(e2eテストが欲しい...) 
    ```bash
    # ProfilePoint
    POINT=2
    REASON_ID=3
    EVENTABBR=EV1
    PROFILE_ID=11
    # POST
    curl -H "Content-Type: application/json" -XPOST -d "{ \"point\": ${POINT},\"reasonId\": ${REASON_ID},\"eventAbbr\": \"${EVENTABBR}\" }" https://api.dev.cloudnativedays.jp/api/v1/profile/${PROFILE_ID}/point
    POINT=3
    curl -H "Content-Type: application/json" -XPOST -d "{ \"point\": ${POINT},\"reasonId\": ${REASON_ID},\"eventAbbr\": \"${EVENTABBR}\" }" https://api.dev.cloudnativedays.jp/api/v1/profile/${PROFILE_ID}/point
    POINT=5
    EVENTABBR=EV2
    curl -H "Content-Type: application/json" -XPOST -d "{ \"point\": ${POINT},\"reasonId\": ${REASON_ID},\"eventAbbr\": \"${EVENTABBR}\" }" https://api.dev.cloudnativedays.jp/api/v1/profile/${PROFILE_ID}/point
    # GET
    curl https://api.dev.cloudnativedays.jp/api/v1/profile/${PROFILE_ID}/points
    curl https://api.dev.cloudnativedays.jp/api/v1/profile/${PROFILE_ID}/points?EventAbbr=EV1

    # Vote
    TRACK_ID=6
    EVENTABBR=EV2
    curl -H "Content-Type: application/json" -XPOST -d "{ \"eventAbbr\": \"${EVENTABBR}\" }" https://api.dev.cloudnativedays.jp/api/v1/talks/${TRACK_ID}/vote
    # 実行したら下記のDynamoDBに保存される
    # https://us-east-2.console.aws.amazon.com/dynamodbv2/home?region=us-east-2#item-explorer?initialTagKey=&table=voteCFP-dev-VoteTableC0BC27A7-1QLPL5FI515Q8
    ```
