### PR TITLE
Refactor/remove cfn output in viewer count lambda

### DIFF
--- a/lib/viewerCountLambda.ts
+++ b/lib/viewerCountLambda.ts
@@ -55,13 +55,6 @@ export function newViewerCountResources(
     }),
   )
 
-  // OutPut
-
-  new CfnOutput(scope, 'viewerCountArnOutPut', {
-    value: getViewerCountFunction.functionArn,
-    exportName: `viewerCountStack-GetViewerCountFunction-Arn-${buildConfig.Environment}`,
-  })
-
   return {
     saveViewerCountFunction,
     getViewerCountFunction,

--- a/test/__snapshots__/statelessStack.test.ts.snap
+++ b/test/__snapshots__/statelessStack.test.ts.snap
@@ -25,17 +25,6 @@ exports[`snapshot test 1`] = `
         ],
       },
     },
-    "viewerCountArnOutPut": {
-      "Export": {
-        "Name": "viewerCountStack-GetViewerCountFunction-Arn-test",
-      },
-      "Value": {
-        "Fn::GetAtt": [
-          "getViewerCount01DE1D78",
-          "Arn",
-        ],
-      },
-    },
   },
   "Parameters": {
     "BootstrapVersion": {


### PR DESCRIPTION
Cfnのdeployが死んでる。
https://ap-northeast-1.console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/events?filteringStatus=active&filteringText=&viewNested=true&hideStacks=false&stackId=arn%3Aaws%3Acloudformation%3Aap-northeast-1%3A607167088920%3Astack%2Fstateless-stg%2Ffe543d10-622c-11ed-933c-0a0006b0f821

![image](https://user-images.githubusercontent.com/76274657/201466057-f2626fad-7663-4bb0-a46d-38052ba719f1.png)

CfnOutputがリファクタリング前後で別物扱いされ、keyが被った扱いになっていることが原因

そもそもapigatewayでFn.importValueをやめてCfnOutput不要となった。なので消した

https://github.com/cloudnativedaysjp/dreamkast-functions/commit/fc6a2cab46754ea00e25d3956cb6b656dc163c68#diff-9d0ae282ee10af190c78cb4a3d4a46cf54a5c3c3bb11e1d027047544fc42610bL291
