### PR TITLE
Fix/rename log group name for apigateway

### DIFF
--- a/lib/apigateway.ts
+++ b/lib/apigateway.ts
@@ -71,7 +71,7 @@ export function newAPIGatewayResources(
       loggingLevel: apigateway.MethodLoggingLevel.INFO,
       accessLogDestination: new apigateway.LogGroupLogDestination(
         new LogGroup(scope, 'ApiLogGroup', {
-          logGroupName: `${id}-apiGateway`,
+          logGroupName: `${id}-apiGateway-${buildConfig.Environment}`,
           retention: RetentionDays.ONE_MONTH,
           removalPolicy: RemovalPolicy.DESTROY,
         }),

--- a/test/__snapshots__/statelessStack.test.ts.snap
+++ b/test/__snapshots__/statelessStack.test.ts.snap
@@ -59,7 +59,7 @@ exports[`snapshot test 1`] = `
     "ApiLogGroup1DEDFC07": {
       "DeletionPolicy": "Delete",
       "Properties": {
-        "LogGroupName": "apiGateway-apiGateway",
+        "LogGroupName": "apiGateway-apiGateway-test",
         "RetentionInDays": 30,
       },
       "Type": "AWS::Logs::LogGroup",


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast-functions/pull/49 でid変数からenv情報が消えたので、現状CloudWatchのLogGroupの名前がdev/stg/prd間で被る設定になっている。


https://github.com/cloudnativedaysjp/dreamkast-functions/blob/be021923d67683fa872bf0dbba74ca93cddc81af/lib/statelessStack.ts#L63

https://github.com/cloudnativedaysjp/dreamkast-functions/blob/be021923d67683fa872bf0dbba74ca93cddc81af/lib/apigateway.ts#L74

この場合、同一リージョンにあるstg/prdの場合、同じLogGroupにログが出力されることになり微妙。
（そもそもデプロイ時にエラーになりそうな気もする 🤔 ）

LogGroupの名前にenv情報を入れ、dev/stg/prdで名前が被らないようにした