### PR TITLE
Chore/update throttling for apigateway

### DIFF
--- a/lib/apigateway.ts
+++ b/lib/apigateway.ts
@@ -70,8 +70,8 @@ export function newAPIGatewayResources(
     restApiName: `dk-functions-${buildConfig.Environment}`,
     deployOptions: {
       stageName: 'v1',
-      throttlingRateLimit: 60,
-      throttlingBurstLimit: 3000,
+      throttlingRateLimit: 10000,
+      throttlingBurstLimit: 5000,
       dataTraceEnabled: true,
       loggingLevel: apigateway.MethodLoggingLevel.INFO,
       accessLogDestination: new apigateway.LogGroupLogDestination(

--- a/test/__snapshots__/statelessStack.test.ts.snap
+++ b/test/__snapshots__/statelessStack.test.ts.snap
@@ -310,8 +310,8 @@ exports[`snapshot test 1`] = `
             "HttpMethod": "*",
             "LoggingLevel": "INFO",
             "ResourcePath": "/*",
-            "ThrottlingBurstLimit": 3000,
-            "ThrottlingRateLimit": 60,
+            "ThrottlingBurstLimit": 5000,
+            "ThrottlingRateLimit": 10000,
           },
         ],
         "RestApiId": {


### PR DESCRIPTION
API Gatewayのthrottleの設定をデフォルトのRate:10000・Burst:5000に設定