### PR TITLE
fix: vote-counter: Catch up to the DynamoDB configuration changes

### DIFF
--- a/tools/cfp-vote-counter/src/query.py
+++ b/tools/cfp-vote-counter/src/query.py
@@ -9,11 +9,12 @@ from boto3.dynamodb.conditions import Key
 from src.types import DynamoResponse, Col
 
 
-DYNAMO_VOTE_TABLE_PRD: Final[str] = "voteCFP-prd-VoteTableC0BC27A7-UKB7XFRIUIX1"
-DYNAMO_VOTE_TABLE_STG: Final[str] = "voteCFP-stg-VoteTableC0BC27A7-84BXPDSTU937"
+DYNAMO_VOTE_TABLE_PRD: Final[str] = "vote-prd"
+DYNAMO_VOTE_TABLE_STG: Final[str] = "vote-stg"
 
 VOTING_PERIOD: Final[dict[str, tuple[datetime, datetime]]] = {
-    "cndt2022": (datetime.fromisoformat('2022-10-01'), datetime.fromisoformat('2022-10-13T18:00:00Z+09:00'))
+    "cndt2022": (datetime.fromisoformat('2022-10-01'), datetime.fromisoformat('2022-10-13T18:00:00Z+09:00')),
+    "cicd2023": (datetime.fromisoformat('2023-01-01'), datetime.fromisoformat('2023-01-25T18:00:00Z+09:00'))
 }
 
 

--- a/tools/cfp-vote-counter/src/types.py
+++ b/tools/cfp-vote-counter/src/types.py
@@ -7,7 +7,7 @@ class Col:
     TS_BY_HOUR: Final[str] = "ts_by_hour"
     TALK_ID: Final[str] = "talkId"
     GLOBAL_IP: Final[str] = "globalIp"
-    EVENT_NAME: Final[str] = "eventName"
+    EVENT_NAME: Final[str] = "eventAbbr"
     COUNT: Final[str] = "count"
     SUM: Final[str] = "sum"
 


### PR DESCRIPTION
CFP投票数の集計ツールの各種パラメータを修正しました。
CNDT2022のときに、CDK実装をリファクタリングしてrandom suffixがつかなくなったあたりが主な要因です。
また、CICD2023の投票期間のレコードも追加しています。